### PR TITLE
Fix Dependence Issue in Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg \
     GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -o msm-iptables util/msm-iptables/main.go util/msm-iptables/constants.go
 
-FROM --platform=$TARGETPLATFORM ubuntu:focal
+FROM --platform=$TARGETPLATFORM ubuntu:22.04
 
 LABEL description="MSM CNI plugin installer."
 


### PR DESCRIPTION
Upgrade base docker image from 20.04 to 22.04, to fix the glibc
dependence issue.

Signed-off-by: Han Qiang <qiang.han@intel.com>
